### PR TITLE
Show captions on embedded videos

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -81,7 +81,7 @@ layout: main
 
             {% if page.abcd_video %}
             <div class="media">
-                <iframe width="560" height="315" src="{{ page.abcd_video}}" frameborder="0"
+                <iframe width="560" height="315" src="{{ page.abcd_video}}?cc_load_policy=1" frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                     allowfullscreen></iframe>
             </div>
@@ -133,7 +133,7 @@ layout: main
 
             {% if page.repronim_video %}
             <div class="media">
-                <iframe width="560" height="315" src="{{ page.repronim_video}}" frameborder="0"
+                <iframe width="560" height="315" src="{{ page.repronim_video}}?cc_load_policy=1" frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                     allowfullscreen>
                 </iframe>
@@ -186,7 +186,7 @@ layout: main
             </h2>
 
             <div class="media">
-                <iframe width="560" height="315" src="{{ page.qa_video}}" frameborder="0"
+                <iframe width="560" height="315" src="{{ page.qa_video}}?cc_load_policy=1" frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                     allowfullscreen>
                 </iframe>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -81,7 +81,7 @@ layout: main
 
             {% if page.abcd_video %}
             <div class="media">
-                <iframe width="560" height="315" src="{{ page.abcd_video}}?cc_load_policy=1" frameborder="0"
+                <iframe width="560" height="315" src="{{ page.abcd_video}}?cc_load_policy=1&cc_lang_pref=en" frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                     allowfullscreen></iframe>
             </div>
@@ -133,7 +133,7 @@ layout: main
 
             {% if page.repronim_video %}
             <div class="media">
-                <iframe width="560" height="315" src="{{ page.repronim_video}}?cc_load_policy=1" frameborder="0"
+                <iframe width="560" height="315" src="{{ page.repronim_video}}?cc_load_policy=1&cc_lang_pref=en" frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                     allowfullscreen>
                 </iframe>
@@ -186,7 +186,7 @@ layout: main
             </h2>
 
             <div class="media">
-                <iframe width="560" height="315" src="{{ page.qa_video}}?cc_load_policy=1" frameborder="0"
+                <iframe width="560" height="315" src="{{ page.qa_video}}?cc_load_policy=1&cc_lang_pref=en" frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                     allowfullscreen>
                 </iframe>


### PR DESCRIPTION
Closes #6. 

Changes proposed:
- Add `?cc_load_policy=1` to all embedded video URLs in order to automatically show captions.