### PR TITLE
Reversed post order

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,7 @@ plugins:
   - jekyll-paginate
   - jemoji
 
-paginate: 8
+paginate: 13
 paginate_path: "/page/:num"
 
 exclude: ["node_modules", "gulpfile.js", "package.json", "yarn.lock"]

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -17,9 +17,8 @@ layout: default
     <h3 class="contact-title">Pages</h3>
     <a class="pagelink" href="{{site.baseurl}}/resources">Resources</a>
     <br/>
-    <a class="pagelink" href="{{site.baseurl}}/project-week-data-exercises">Project Week Data Exercises</a>
+    <a class="pagelink" href="{{site.baseurl}}/project-week-data-exercises">Project Month Prep Exercises</a>
     <br/>
-    <a class="pagelink" href="https://abcd-repronim.us17.list-manage.com/track/click?u=ae1754f263f423a3c0cc04237&id=5c29cfb327&e=0b9a74ba96">Session 1 Survey</a>
     </section> <!-- End pages section -->
   <footer>
     <section class="contact">

--- a/_posts/2022-01-17-week-2.md
+++ b/_posts/2022-01-17-week-2.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Week 2
-date: 2022-01-10 12:00:00
+date: 2022-01-17 12:00:00
 term: second
 description: Week 2 course materials # Add post description (optional)
 detailed-description: Drs. Wesley Thompson and Dorota Jarecka talk about accessing ABCD data using DEAP, how to use the command line, and introduce git as a resource for version control.

--- a/_posts/2022-03-28-week-12.md
+++ b/_posts/2022-03-28-week-12.md
@@ -25,3 +25,7 @@ assignment_links: #["https://docs.google.com/forms/d/e/1FAIpQLSc_yxL4IuTlJPzxd3y
 assignment_names: #["Week 12 Data Exercise"]qa_video: https://www.youtube.com/embed/QFngbg74H1o
 qa_video: https://www.youtube.com/embed/zAqkd9sSspk
 ---
+
+<!---
+Please fill out our Session 1 Survey here: https://abcd-repronim.us17.list-manage.com/track/click?u=ae1754f263f423a3c0cc04237&id=5c29cfb327&e=0b9a74ba96
+--->

--- a/_posts/template.md
+++ b/_posts/template.md
@@ -2,7 +2,9 @@
 layout: post
 title: Week X
 date: 2019-10-16 12:00:00
+term:
 description: Week X course materials # Add post description (optional)
+detailed-description:
 img: weekxx.jpg # Add image post (optional)
 
 abcd_title:
@@ -19,5 +21,7 @@ repronim_reading_names:
 
 qa_doc:
 exercises:
+assignment_links:
+assignment_names:
 qa_video:
 ---

--- a/index.html
+++ b/index.html
@@ -1,7 +1,8 @@
 ---
 layout: main
 ---
-{% for post in paginator.posts %}
+{% for post in paginator.posts reversed %}
+
     <!---to hide the resources page-->
     {% if post.hidden != true %}
         <article class="post">


### PR DESCRIPTION
Reverset post order via reversing date ordering `intex.html` *and*  increasing pagination to 13 posts per page (it was at 8). This is a bit of a hack-y solution but I can't seem to find support in Jekyll flow for reversing post ordering for posts dated in the future!