### PR TITLE
Add last year's materials back in

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -10,12 +10,27 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Build the site in the jekyll/builder container
       run: |
         docker run \
         -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
         jekyll/builder:latest /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"
 
+    # Use GitHub Actions' cache to shorten build times and decrease load on servers
+    - uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+
+    # Standard usage
+    - uses:  helaili/jekyll-action@v2
+      with:
+        build_only: true
+
+    # Upload the artifact
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -29,4 +29,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: my-artifact
-        path: ${{ github.workspace }}/_site/index.html
+        path: ${{ github.workspace }}/build/index.html

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -12,9 +12,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
     - name: Build the site in the jekyll/builder container
+      uses: actions/checkout@v2
       run: |
         docker run \
         -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
         jekyll/builder:latest /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: my-artifact
+        path: ${{ github.workspace }}/_site/index.html

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,14 +1,11 @@
 name: Jekyll site CI
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/checkout@v2
     - name: Build the site in the jekyll/builder container
-      uses: actions/checkout@v2
       run: |
         docker run \
         -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -11,12 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Build the site in the jekyll/builder container
-      run: |
-        docker run \
-        -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
-        jekyll/builder:latest /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"
-
     # Use GitHub Actions' cache to shorten build times and decrease load on servers
     - uses: actions/cache@v2
       with:

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -28,5 +28,5 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
-        name: my-artifact
-        path: ${{ github.workspace }}/build/index.html
+        name: built-site
+        path: ${{ github.workspace }}/build/

--- a/_config.yml
+++ b/_config.yml
@@ -30,8 +30,8 @@ plugins:
   - jekyll-paginate
   - jemoji
 
-paginate: 13
-paginate_path: "/page/:num"
+# paginate: 13
+# paginate_path: "/page/:num"
 
 exclude: ["node_modules", "gulpfile.js", "package.json", "yarn.lock"]
 

--- a/_config.yml
+++ b/_config.yml
@@ -34,3 +34,6 @@ paginate: 13
 paginate_path: "/page/:num"
 
 exclude: ["node_modules", "gulpfile.js", "package.json", "yarn.lock"]
+
+# What is the current term
+current_term: 2

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -19,6 +19,8 @@ layout: default
     <br/>
     <a class="pagelink" href="{{site.baseurl}}/project-week-data-exercises">Project Month Prep Exercises</a>
     <br/>
+    <a class="pagelink" href="{{site.baseurl}}/past-materials">Materials from Past Terms</a>
+    <br/>
     </section> <!-- End pages section -->
   <footer>
     <section class="contact">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,10 +8,10 @@ layout: main
         <h1 class="page-title">{{page.title}}</h1>
         <div class="page-date"><span>{{page.date | date: '%b %d %Y'}}&nbsp;&nbsp;&nbsp;&nbsp;</span></div>
       </header>
-        <div class="row" align="left">
+      <div class="row" align="left">
 
-      <!-- Begin Term conditional Content -->
-        {% if page.term %}
+        <!-- Begin Term conditional Content -->
+        {% if page.term == site.current_term %}
             <!-- Begin Header Description Content -->
             <div class="smallhead">
                 <b>{{page.title}}</b>: {{page.detailed-description}}

--- a/_posts/2020-10-16-term-1-week-1.md
+++ b/_posts/2020-10-16-term-1-week-1.md
@@ -1,0 +1,39 @@
+---
+layout: post
+title: Course Year 1 Week 1
+date: 2020-10-16 12:00:00
+term: 1
+description: Week 1 course materials. # Add post description (optional)
+img: week01.jpg # Add image post (optional)
+fig-caption: # Add figcaption (optional)
+tags: []
+
+qa_doc: https://docs.google.com/document/d/14NLnourpjasNaJw8HjAQXDXruULLYN4NK-yNzY0K1Xo/edit?usp=sharing
+exercises: "https://forms.gle/ybaY6HgLnfcYQ7kXA"
+qa_video: "https://www.youtube.com/embed/MUIuePnQzX8"
+
+abcd_title: Introduction to the ABCD Study®
+abcd_video: https://www.youtube.com/embed/z6jcWAmDhF0
+abcd_slides: "https://drive.google.com/file/d/1o6oYZ-2WDIrOoTMsi3F8idUxed3aZStm/view?usp=sharing"
+abcd_reading_links: ["https://www.sciencedirect.com/science/article/pii/S1878929317300725", "https://www.sciencedirect.com/science/article/pii/S1878929317301883", "https://www.sciencedirect.com/science/article/pii/S1878929317302268"]
+abcd_reading_names: ["Volkow et al.: 'The conception of the ABCD study: From substance use to a broad NIH collaboration'", "Jernigan et al.: 'Introduction (Developmental Cognitive Neuroscience)'", "Auchter et al.: 'A description of the ABCD organizational structure and communication framework'"]
+
+repronim_title: Introduction to ReproNim
+repronim_video: https://www.youtube.com/embed/x5PgA3tzuhg
+repronim_slides: "https://docs.google.com/presentation/d/1Yw3BY4u9pw8s7be9K6zeCFcUAZ430kQoe5_m0-ooFUw/edit?usp=sharing"
+repronim_reading_links: ["https://www.frontiersin.org/articles/10.3389/fninf.2019.00001/full", "https://www.nature.com/articles/s41562-016-0021"]
+repronim_reading_names: ["Kennedy et al.: 'Everything Matters: The ReproNim Perspective on Reproducible Neuroimaging'", "Munafò et al.: 'A manifesto for reproducible science'"]
+---
+**Pre-Course Survey**: We would like for all students (Enrolled and Observer) to complete a Pre-Course Survey so that we will have metrics with which to measure our success at the conclusion of ABCD-ReproNim. **Please complete the Pre-Course Survey before viewing the Week 1 videos.**
+
+**Week 1 Quiz**: Each week, ABCD-ReproNim students will complete a data exercise to reinforce course content while developing practical skills. Week 1 of the course is an introductory week that does not include a data exercise. Instead, we ask that students complete a quiz to confirm that they are able to access course materials on our various platforms. Additional questions will confirm introductory knowledge of the ABCD Study and ReproNim. **Please complete the Week 1 Quiz after viewing the Week 1 videos.**
+
+**Enrolled Students**:
+
+The Pre-Course Survey and Week 1 Quiz should be completed in [Canvas](https://develop.fiu.edu/courses/abcd-repronim-course-reproducible-analyses-of-abcd-data).
+
+**Observer Students**:
+
+Pre-Course Survey: [https://forms.gle/o1ucqPSfhpvgvLh78](https://forms.gle/o1ucqPSfhpvgvLh78)
+
+Week 1 Quiz: [https://forms.gle/ybaY6HgLnfcYQ7kXA](https://forms.gle/ybaY6HgLnfcYQ7kXA)

--- a/_posts/2020-10-23-term-1-week-2.md
+++ b/_posts/2020-10-23-term-1-week-2.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: Course Year 1 Week 2
+date: 2020-10-23 12:00:00
+term: 1
+description: Week 2 course materials # Add post description (optional)
+img: week02.jpg # Add image post (optional)
+
+qa_doc: https://docs.google.com/document/d/1VcCpNbyph5tLGRVspWtLPVsogz2UMbje2f5745wWKus/edit?usp=sharing
+exercises: https://forms.gle/K68rcQewgRmXdyBU9
+qa_video: "https://www.youtube.com/embed/xcgDafWEBM8"
+
+abcd_title: Data Access, NDA, and DEAP
+abcd_video: https://www.youtube.com/embed/bfy04piqFDs
+abcd_slides: "https://drive.google.com/file/d/16BNJ8JMI75vFtoAGd9CzyKiqcZxR2Q0L/view?usp=sharing"
+abcd_reading_links: ["https://www.biorxiv.org/content/10.1101/2020.09.01.276451v1.full"]
+abcd_reading_names: ["Dick et al.: 'Meaningful Effects in the Adolescent Brain Cognitive Development Study'"]
+
+repronim_title: Git & Basics
+repronim_video: https://www.youtube.com/embed/SyKmry47SsY
+repronim_slides: "https://drive.google.com/file/d/11BQ5t5V16UdXq50lLHkYfGoRyUQmfcCe/view?usp=sharing"
+repronim_reading_links: ["https://swcarpentry.github.io/shell-novice/01-intro/index.html", "https://swcarpentry.github.io/shell-novice/", "http://practical-neuroimaging.github.io/git_parable.html#the-git-parable"]
+repronim_reading_names: ["Introducing shell (part 1)", "Software Carpentry on Unix: Read at least one section of parts 2 - 7", "A git parable"]
+---

--- a/_posts/2020-10-30-term-1-week-3.md
+++ b/_posts/2020-10-30-term-1-week-3.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: Course Year 1 Week 3
+date: 2020-10-30 12:00:00
+term: 1
+description: Week 3 course materials # Add post description (optional)
+img: week03.jpg # Add image post (optional)
+
+qa_doc: https://docs.google.com/document/d/1TeyWbal-j7U47lGbVJffy1tn6djd6EW7NXay8tozTVw/edit?usp=sharing
+exercises: https://docs.google.com/forms/d/e/1FAIpQLSfZF-hHM5zNdcIscL3sq8q7pmhlna4OOtKM57sQXzr1tkpnFA/viewform?usp=sf_link
+qa_video: https://www.youtube.com/embed/WP5gRkA8jew
+
+abcd_title: Sampling, Recruitment, and Retention
+abcd_video: https://www.youtube.com/embed/pvbRt5SntE8
+abcd_slides: ["https://drive.google.com/file/d/1-nRoA_F56oOQ4ehiIjsWlgsH0JP2kJLM/view?usp=sharing"]
+abcd_reading_links: ["https://www.sciencedirect.com/science/article/pii/S1878929317301809", "https://jamanetwork.com/journals/jamapediatrics/article-abstract/2737910"]
+abcd_reading_names: ["Garavan et al.: 'Recruiting the ABCD sample: Design considerations and procedures'", "Compton et al.: 'Ensuring the Best Use of Data: The Adolescent Brain Cognitive Development Study'"]
+
+repronim_title: Containers & ReproEnv
+repronim_video: ["https://www.youtube.com/embed/UHw-DVgm-pE", "https://www.youtube.com/embed/5seOeecBI5c"]
+repronim_slides: ["https://drive.google.com/file/d/1lRfo30076maHOPLd4M2TMvRfB833mELI/view?usp=sharing", "https://drive.google.com/file/d/1_hSPS5M83jhAFh4hRfAcDnAAwoNU9vOO/view?usp=sharing"]
+repronim_reading_links: ["https://www.freecodecamp.org/news/a-beginner-friendly-introduction-to-containers-vms-and-docker-79a9e3e119b/", "https://sylabs.io/guides/3.6/user-guide/introduction.html"]
+repronim_reading_names: ["A Beginner-Friendly Introduction to Containers, VMs and Docker", "Introduction to Singularity"]
+---

--- a/_posts/2020-11-06-term-1-week-4.md
+++ b/_posts/2020-11-06-term-1-week-4.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: Course Year 1 Week 4
+date: 2020-11-06 12:00:00
+term: 1
+description: Week 4 course materials # Add post description (optional)
+img: week04.jpg # Add image post (optional)
+
+qa_doc: https://docs.google.com/document/d/12_hGm86jZBFJXIFGSLQPNuzVdr9EGbqvBqSCJ7P2mgw/edit?usp=sharing
+exercises: https://docs.google.com/forms/d/e/1FAIpQLSdPcLUG9bLqIGX3xOTENX-Z1p1lkY8lSgazJgcNECHFwtVgLQ/viewform?usp=sf_link
+qa_video: https://www.youtube.com/embed/QfhbPF4d1pM
+
+abcd_title: Imaging Measures
+abcd_video: https://www.youtube.com/embed/I7Y6jmDMDlE
+abcd_slides: https://drive.google.com/file/d/1yxv88UUWQUFLHdZLEo7wNjai3obT5aqB/view?usp=sharing
+abcd_reading_links: ["https://www.sciencedirect.com/science/article/pii/S1878929317301214", "https://doi.org/10.1016/j.neuroimage.2019.116091", "https://www.biorxiv.org/content/10.1101/457739v1"]
+abcd_reading_names: ["Casey et al.: 'The Adolescent Brain Cognitive Development (ABCD) study: Imaging acquisition across 21 sites'", "Hagler et al.: 'Image processing and analysis methods for the Adolescent Brain Cognitive Development Study'", "Open access version of Hagler et al."]
+
+repronim_title: Pre-Registration and P-Hacking
+repronim_video: https://www.youtube.com/embed/Bz8_AVXI5c8
+repronim_slides: "https://drive.google.com/file/d/1K5elUnQ5-0FW7kMIknuksjIrxXLmnnkg/view?usp=sharing"
+repronim_reading_links: ["https://doi.org/10.1177/0956797611417632", "https://doi.org/10.1038/nrn3475", "https://doi.org/10.1038/s41586-020-2314-9"]
+repronim_reading_names: ["Simmons et al.: 'False-Positive Psychology: Undisclosed Flexibility in Data Collection and Analysis Allows Presenting Anything as Significant'", "Button et al.: 'Power failure: why small sample size undermines the reliability of neuroscience'", "Botvinik-Nezer et al.: 'Variability in the analysis of a single neuroimaging dataset by many teams'"]
+---
+
+We have added two quick questionnaires for Enrolled Students on the course [Canvas](https://develop.fiu.edu/courses/abcd-repronim-course-reproducible-analyses-of-abcd-data). The first is a short quiz showing you how to access ABCD-ReproNim JupyterHub (the cloud-based computational platform we use for Project Week) and the second is a one question survey about your ABCD Data Access Request status. If you are an Enrolled Student please fill both out at your earliest convenience!

--- a/_posts/2020-11-13-term-1-week-5.md
+++ b/_posts/2020-11-13-term-1-week-5.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: Course Year 1 Week 5
+date: 2020-11-13 12:00:00
+term: 1
+description: Week 5 course materials # Add post description (optional)
+img: week05.jpg # Add image post (optional)
+
+qa_doc: https://docs.google.com/document/d/1L8adz8kON3ypMiSeCgX1IufyXvj446kcYUC_mALj_yY/edit?usp=sharing
+exercises: https://docs.google.com/forms/d/e/1FAIpQLSffX6JYZg_u4EL32exQpSYJRffjBTJDg01zNHhyG3xaOUs2fQ/viewform?usp=sf_link
+qa_video: https://www.youtube.com/embed/Rt-XY2UhpzI
+
+abcd_title: Neurocognitive Assessments
+abcd_video: https://www.youtube.com/embed/QcnsPmcvjrc
+abcd_slides: https://drive.google.com/file/d/1NAKaBtbujVOghuD5KVlWcqqU89FSHjj9/view?usp=sharing
+abcd_reading_links: ["https://pubmed.ncbi.nlm.nih.gov/30595399/"]
+abcd_reading_names: ["Thompson et al.: 'The structure of cognition in 9 and 10 year-old children and associations with problem behaviors: Findings from the ABCD study's baseline neurocognitive battery'"]
+
+repronim_title: FAIR Data/Semantic Markup 1
+repronim_video: https://www.youtube.com/embed/wc98OyRho3E
+repronim_slides: https://drive.google.com/file/d/1pAlm2fG11FzGrky11gK07BybwMe3E0PN/view?usp=sharing
+repronim_reading_links: ["http://www.repronim.org/module-FAIR-data/", "https://www.nature.com/articles/sdata201618"]
+repronim_reading_names: ["Data and the FAIR Principles", "Wilkinson et al.: 'The FAIR Guiding Principles for scientific data management and stewardship'"]
+---

--- a/_posts/2020-11-20-term-1-week-6.md
+++ b/_posts/2020-11-20-term-1-week-6.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: Course Year 1 Week 6
+date: 2020-11-20 12:00:00
+term: 1
+description: Week 6 course materials # Add post description (optional)
+img: week06.jpg # Add image post (optional)
+
+qa_doc: https://docs.google.com/document/d/1zaYO_9EF9knqR9Rn9GfjNVlIiBTb81VhLGbT7Q5JptU/edit?usp=sharing
+exercises: https://docs.google.com/forms/d/e/1FAIpQLSdKPufx8ZLh5FZIEQY_umbZxhW9sgeFqL1qS7uVnPjWPNXkfQ/viewform?usp=sf_link
+qa_video: https://www.youtube.com/embed/EuSWBfAXeDM
+
+abcd_title: Substance Use Assessments
+abcd_video: https://www.youtube.com/embed/Yy8mA8Teb3E
+abcd_slides: "https://drive.google.com/file/d/1Gz2lskP_xTCqRjBodu-B_gz73Yj51_jd/view?usp=sharing"
+abcd_reading_links: ["https://www.sciencedirect.com/science/article/pii/S1878929317300890"]
+abcd_reading_names: ["Lisdahl et al.: 'Adolescent brain cognitive development (ABCD) study: Overview of substance use assessment methods'"]
+
+repronim_title: FAIR Data/Semantic Markup 2
+repronim_video: https://www.youtube.com/embed/-Y-3OBDZJgo
+repronim_slides: "https://drive.google.com/file/d/1GhITgMj92Q83hxRiaksIB-Wkcozh0_r-/view?usp=sharing"
+repronim_reading_links: ["https://doi.org/10.1101/053934", "https://doi.org/10.1016/j.neuroimage.2013.05.094", "https://www.nature.com/articles/sdata201644", "https://bids.neuroimaging.io/"]
+repronim_reading_names: ["Nichols et al.: 'Linked Data in Neuroscience: Applications, Benefits, and Challenges'", "Keator et al.: 'Towards structured sharing of raw and derived neuroimaging data across existing resources'", "Gorgolewski et al.: 'The brain imaging data structure, a format for organizing and describing outputs of neuroimaging experiments'", "The BIDS website"]
+---

--- a/_posts/2021-01-15-term-1-week-7.md
+++ b/_posts/2021-01-15-term-1-week-7.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: Course Year 1 Week 7
+date: 2021-01-15 12:00:00
+term: 1
+description: Week 7 course materials # Add post description (optional)
+img: week07.jpg # Add image post (optional)
+
+abcd_title: Demographic, Physical, and Mental Health Assessments
+abcd_video: https://www.youtube.com/embed/VxwWQRvE7QY
+abcd_slides: "https://drive.google.com/file/d/1gE0_aA3Fm8oCjZfCq51V-unI-UFJM_uG/view?usp=sharing"
+abcd_reading_links: ["https://www.sciencedirect.com/science/article/pii/S1878929317300683", "https://pubmed.ncbi.nlm.nih.gov/32541809/"]
+abcd_reading_names: ["Demographic, physical and mental health assessments in the adolescent brain and cognitive development study: Rationale and description", "The ABCD study: understanding the development of risk for mental and physical health outcomes"]
+
+repronim_title: Scientific Questions and Statistical Issues
+repronim_video: https://www.youtube.com/embed/auzLLbQPMfY
+repronim_slides: "https://drive.google.com/file/d/1yJRj8xR3bqjSh0esoIcqM4vDJtXUxhzY/view?usp=sharing"
+repronim_reading_links: ["https://pubmed.ncbi.nlm.nih.gov/28053326/",
+"https://www.datascienceassn.org/sites/default/files/Power%20Failure%20-%20Why%20Small%20Sample%20Size%20Undermines%20the%20Reliability%20of%20Neuroscience.pdf",
+"https://pubmed.ncbi.nlm.nih.gov/28841086/"]
+repronim_reading_names: ["Scanning the horizon: towards transparent and reproducible neuroimaging research", "Power failure: why small sample size undermines the reliability of neuroscience", "Choosing Prediction Over Explanation in Psychology: Lessons From Machine Learning"]
+
+qa_doc: https://docs.google.com/document/d/1I4_bFKG4OJTR9sPm7F6mGR9ENrx-C5YbAG5GsnBEH5o/edit?usp=sharing
+exercises: https://docs.google.com/forms/d/e/1FAIpQLSdAqZj06D6F7mlpe-XPR53d_wuiOn1zNX-TljpYPidxUXz9Eg/viewform?usp=sf_link
+qa_video: https://www.youtube.com/embed/IQU77HcUfwI
+---

--- a/_posts/2021-01-22-term-1-week-8.md
+++ b/_posts/2021-01-22-term-1-week-8.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: Course Year 1 Week 8
+date: 2021-01-22 12:00:00
+term: 1
+description: Week 8 course materials # Add post description (optional)
+img: week08.jpg # Add image post (optional)
+
+abcd_title: Culture and Environment Assessments
+abcd_video: https://www.youtube.com/embed/EbHXALb484k
+abcd_slides: https://drive.google.com/file/d/1H5hhANoQXz3XlAVf0zPhB9KKm9OlGjob/view?usp=sharing
+abcd_reading_links: ["https://www.sciencedirect.com/science/article/pii/S1878929317300348", "https://pubmed.ncbi.nlm.nih.gov/29627333/", "/materials/assets/pdfs/PreventingStigmatizingResearch.pdf"]
+abcd_reading_names: ["A brief validated screen to identify boys and girls at risk for early marijuana use", "Assessment of culture and environment in the Adolescent Brain and Cognitive Development Study: Rationale, description of measures, and early data", "Preventing Stigmatizing Research"]
+
+repronim_title: Data Versioning and Tranformation with DataLad
+repronim_video: https://www.youtube.com/embed/udLVUyZQanw
+repronim_slides: https://drive.google.com/file/d/1l-DNffjYm7I3YnwuC9Ia0mcoYMShCDLj/view?usp=sharing
+repronim_reading_links: ["http://handbook.datalad.org/en/latest/intro/philosophy.html", "http://handbook.datalad.org/en/latest/basics/101-136-cheatsheet.html", "https://www.youtube.com/watch?v=pIGFS8XDjco", "http://handbook.datalad.org/en/latest/code_from_chapters/ABCD.html"]
+repronim_reading_names: ["A brief overview of DataLad", "DataLad cheat sheet", "DataLad - Decentralized Management of Digital Objects for Open Science (Video)", "Datalad ABCD handbook"]
+
+qa_doc: https://docs.google.com/document/d/17TKLPPND3gOVXmMS67RjA-mQUVziWEncfc4ms2A7Ovs/edit?usp=sharing
+exercises: https://docs.google.com/forms/d/e/1FAIpQLSeJsKEHp2qFKSQK8JVLI1r6rOwz7LhWAnUU6KebugcsjwyKWQ/viewform?usp=sf_link
+qa_video: https://www.youtube.com/embed/WIBQ7k5rVhc
+---

--- a/_posts/2021-01-29-term-1-week-9.md
+++ b/_posts/2021-01-29-term-1-week-9.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: Course Year 1 Week 9
+date: 2021-01-29 12:00:00
+term: 1
+description: Week 9 course materials # Add post description (optional)
+img: week09.jpg # Add image post (optional)
+
+abcd_title: Biospecimens
+abcd_video: https://www.youtube.com/embed/QcsifMz5_fQ
+abcd_slides: https://drive.google.com/file/d/1qbHCoiYM6cVhnVfnRfFbb0pTv2pSw6-Q/view
+abcd_reading_links: ["https://doi.org/10.1016/j.dcn.2018.03.005"]
+abcd_reading_names: ["Uban et al.: 'Biospecimens and the ABCD study: Rationale, methods of collection, measurement and early data'"]
+
+repronim_title: Reproducible Workflows & Analyses
+repronim_video: https://www.youtube.com/embed/OQ5e0xoSoyY
+repronim_slides: https://docs.google.com/presentation/d/1vsznawj812RI2MJBMN-MW5pZdoHrla74bOuKTS4Cz2o/edit?usp=sharing
+repronim_reading_links: ["https://doi.org/10.1038/s41586-020-2314-9", "https://f1000research.com/articles/6-124"]
+repronim_reading_names: ["Botvinik-Nezer et al.: 'Variability in the analysis of a single neuroimaging dataset by many teams'", "Ghosh et al.: 'A very simple, re-executable neuroimaging publication'"]
+
+qa_doc: https://docs.google.com/document/d/11DvcQLF1Qv8l8olqVd5LvJdCaSAQzntCU5a4RCIpvXw/edit?usp=sharing
+exercises: https://docs.google.com/forms/d/e/1FAIpQLSd_0lXO7pc8czrIVGT2YzwSZhTSmgco1p7B7y8D6E5MaF9_Sw/viewform?usp=sf_link
+qa_video:
+---

--- a/_posts/2021-02-05-term-1-week-10.md
+++ b/_posts/2021-02-05-term-1-week-10.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: Course Year 1 Week 10
+date: 2021-02-05 12:00:00
+term: 1
+description: Week 10 course materials # Add post description (optional)
+img: week10.jpg # Add image post (optional)
+
+abcd_title: Novel Technologies – Mobile, Wearable, and Social Media
+abcd_video: https://www.youtube.com/embed/MFk98_ykknQ
+abcd_slides: https://drive.google.com/file/d/1IEYN2qlAdZNsSSG-M8kRAuIqwnJdH0lq/view?usp=sharing
+abcd_reading_links: ["https://pubmed.ncbi.nlm.nih.gov/29636283/", "https://pubmed.ncbi.nlm.nih.gov/30339913/"]
+abcd_reading_names: ["Current, future and potential use of mobile and wearable technologies and social media data in the ABCD study to increase understanding of contributors to child health", "Screen media activity and brain structure in youth: Evidence for diverse structural correlation networks from the ABCD study"]
+
+repronim_title: ReproMan – Execution and Environment Manager
+repronim_video: https://www.youtube.com/embed/grIVFbYH7YE
+repronim_slides: https://drive.google.com/file/d/17YdE7wHXEG3P-mDj5qfDQIDTTRQSqzdy/view?usp=sharing
+repronim_reading_links: ["https://media.giphy.com/media/1iu8uG2cjYFZS6wTxv/giphy.gif"]
+repronim_reading_names: ["No readings for this week's ReproNim lecture!"]
+
+qa_doc: https://docs.google.com/document/d/1GYoQM7O4UA59MiK1EMlMyFA1qlEf0uzlpguPPHmwNgQ/edit?usp=sharing
+exercises: https://docs.google.com/forms/d/e/1FAIpQLSfPUWpQ6IbiOoZxGVwN0iGgwllJum25eW72PnK0Gwp6LlLQbg/viewform?usp=sf_link
+qa_video: https://www.youtube.com/embed/4pEOGYcbx64
+---

--- a/_posts/2021-02-12-term-1-week-11.md
+++ b/_posts/2021-02-12-term-1-week-11.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: Course Year 1 Week 11
+date: 2021-02-12 12:00:00
+term: 1
+description: Week 11 course materials # Add post description (optional)
+img: week11.jpg # Add image post (optional)
+
+abcd_title: Visualizing ABCD Data
+abcd_video: https://www.youtube.com/embed/3r73oYta0yA
+abcd_slides: https://mybinder.org/v2/gh/62442katieb/NH19-Visualization/binder-live
+abcd_reading_links: ["https://github.com/62442katieb/NH19-Visualization/tree/binder-live", "https://github.com/neurohackademy/visualization-in-python/blob/master/visualization-in-python.ipynb", "https://doi.org/10.1109/ICSCEE.2018.8538413", "https://towardsdatascience.com/introduction-to-data-visualization-in-python-89a54c97fbed", "https://towardsdatascience.com/complete-guide-to-data-visualization-with-python-2dd74df12b5e"]
+abcd_reading_names: ["GitHub repo with the notebooks + data from lecture","Tal Yarkoni's Neurohackademy 2018 data visualization tutorial", "Fahad & Yahya: Big Data Visualization: Allotting by R and Python with GUI Tools", "Towards Data Science: Introduction to Data Visualization in Python", "Towards Data Science: Complete Guide to Data Visualization with Python"]
+
+repronim_title: "ReproPub: The Re-Executable Publication"
+repronim_video: https://www.youtube.com/embed/PlTJpErMCEk
+repronim_slides: https://drive.google.com/file/d/1H_bhwiIVBMLo617yNodqqZxySAr7op8c/view?usp=sharing
+repronim_reading_links: ["https://f1000research.com/articles/6-124", "https://zenodo.org/record/3336609#.X3IzuNNKjOQ"]
+repronim_reading_names: ["A very simple, re-executable neuroimaging publication", "The ReproPub: A hybrid research object for supporting publication-level re-execution and generalization of neuroimaging research findings"]
+qa_doc: https://docs.google.com/document/d/1j75s_fcFSfkdjMatbQu8KHjaQ2AFxJ2AOI3qEf9JNUA/edit?usp=sharing
+exercises: https://docs.google.com/forms/d/e/1FAIpQLSeAxFWoKckQkKheJLKOKKafoSMD-37iWzocZCaNR_V8KWlbcw/viewform?usp=sf_link
+qa_video: https://www.youtube.com/embed/QFngbg74H1o
+---

--- a/_posts/2021-02-19-term-1-week-12.md
+++ b/_posts/2021-02-19-term-1-week-12.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: Course Year 1 Week 12
+date: 2021-02-19 12:00:00
+term: 1
+description: Week 12 course materials # Add post description (optional)
+img: week12.jpg # Add image post (optional)
+
+abcd_title: "Analytic Approaches: Longitudinal Modeling and Quantifying Change"
+abcd_video: https://www.youtube.com/embed/qnNCw4o5NDA
+abcd_slides: https://drive.google.com/file/d/1ph4CH5kiFgEmFRlkiFsenI4BN0HPyBaO/view?usp=sharing
+abcd_reading_links: ["https://www.sciencedirect.com/science/article/pii/S1878929317300713", "https://www.sciencedirect.com/science/article/pii/S1878929317300300"]
+abcd_reading_names: ["Current methods and limitations for longitudinal fMRI analysis across development", "Longitudinal modeling in developmental neuroimaging research: Common challenges, and solutions from developmental psychology"]
+
+repronim_title: "Analytic Approaches: Reproducible Practices in Machine Learning"
+repronim_video: https://www.youtube.com/embed/LAddDaqUe0A
+repronim_slides: https://drive.google.com/file/d/1C5b0drHuShcQix11NrVzbu_SGSElry3R/view?usp=sharing
+repronim_reading_links: ["https://arxiv.org/abs/1706.07581"]
+repronim_reading_names: ["Cross-validation failure: small sample sizes lead to large error bars"]
+
+qa_doc: https://docs.google.com/document/d/1N9n25GGCM5AaOcfkpmh2OGohZUrprIInpCwuKua4QhM/edit?usp=sharing
+exercises: https://docs.google.com/forms/d/e/1FAIpQLSc_yxL4IuTlJPzxd3y2hc7bVV-SgPhmFKJP1ZtQoiiS1x2xUQ/viewform?usp=sf_link
+qa_video: https://www.youtube.com/embed/zAqkd9sSspk
+---

--- a/_posts/2021-02-26-term-1-week-13.md
+++ b/_posts/2021-02-26-term-1-week-13.md
@@ -1,0 +1,20 @@
+---
+layout: resources
+title: Course Year 1 Week 13
+date: 2021-02-26 12:00:00
+term: 1
+description: Week 13 course materials # Add post description (optional)
+img: week13.jpg # Add image post (optional)
+---
+
+
+If you missed the final ABCD-ReproNim Q&A Session (held on Feb 26, 2021), in which our wonderful students gave pitches for each of the projects for Project Week, you can watch the reply of it here: https://www.youtube.com/embed/zTOleP0JIqo
+
+
+If you plan to participate in Project Week make sure to attend this session! ABCD-ReproNim students who [proposed projects](https://github.com/ABCD-ReproNim/projects/issues) will make pitches describing their ideas and what they hope to accomplish over Project Week. We will be asking *all* Project Week participants to join a project team for Project Week and this is your chance to see what projects are available to help with! If you cannot attend live then that's OK -- we will post a recording of the Q&A on this page after it airs.
+
+Resources for Project Week:
+
+Please check out our [Project Week Outline](https://docs.google.com/document/d/1y5RqRw_ow7O3hTgwFBBsa6T9NaczIDwNM35qcRrw8fk/edit?usp=sharing) and [Project Week FAQ](https://docs.google.com/document/d/1fGYlcQQBqxsoEMnD3al1cKg1Zz0dXGY0thmcrRRYydc/edit?usp=sharing)
+
+[Here](https://docs.google.com/presentation/d/1yaISzpru7dApTVccquoJDVZxbryuiSyHnMLNUR5McTM/edit?usp=sharing) is a presentation about what to expect going into Project Week and how to prepare.

--- a/_posts/2021-02-27-term-1-project-week.md
+++ b/_posts/2021-02-27-term-1-project-week.md
@@ -1,0 +1,22 @@
+---
+layout: resources
+title: Course Year 1 Project Week
+date: 2021-03-08 12:00:00
+term: 1
+description: Project Week # Add post description (optional)
+img: project_week.jpg # Add image post (optional)
+---
+
+Check out the proposed projects [here](https://github.com/ABCD-ReproNim/projects/issues)! Please note that only individuals who have obtained [ABCD data access](https://docs.google.com/document/d/18hsT2x15bypuXFcfMQb9Ck_YEB7VvY2j4w5hwbV78A4/edit?usp=sharing) and have provided us with confirmation of their Data Use Certifications (DUCs) will be able to participate in Project Week.
+
+**Project Week Schedule:** The schedule for Project Week can be found on the [ABCD-ReproNim Google Calendar](https://calendar.google.com/calendar?cid=YWJjZHJlcHJvbmltQGdtYWlsLmNvbQ). You can also view a detailed description of events on the [Project Week Outline](https://docs.google.com/document/d/1y5RqRw_ow7O3hTgwFBBsa6T9NaczIDwNM35qcRrw8fk/edit?usp=sharing)
+
+**Resources for Project Week:**
+
+• Our virtual meeting place for Project Week will be on [Gather.Town](https://gather.town/app/vC4xzIIrfbFvptPB/abcd-repronim). The password to join has been emailed to you. Feel free to use this space to meet with your project team as needed or to virtually hang out with others during the week (there's a game room!) All presentations will be held in the lecture hall marked as room 400 in the Gather.Town space. The lecture hall is located all the way to the right of your screen when you enter.
+
+• Project teams will be communicating primarily via private channels in the [ABCD-ReproNim Slack](http://abcd-repronim.slack.com). If you are attending Project Week please [send us a message](mailto:info@abcd-repronim.org) so that we can add you to the appropriate Project Week Slack channels.
+
+• Please check out our [Project Week Outline](https://docs.google.com/document/d/1y5RqRw_ow7O3hTgwFBBsa6T9NaczIDwNM35qcRrw8fk/edit?usp=sharing) and [Project Week FAQ](https://docs.google.com/document/d/1fGYlcQQBqxsoEMnD3al1cKg1Zz0dXGY0thmcrRRYydc/edit?usp=sharing) for more information about Project Weekl
+
+• [Here](https://docs.google.com/presentation/d/1yaISzpru7dApTVccquoJDVZxbryuiSyHnMLNUR5McTM/edit?usp=sharing) is a presentation about what to expect and how to prepare.

--- a/_posts/2022-01-10-week-1.md
+++ b/_posts/2022-01-10-week-1.md
@@ -2,7 +2,7 @@
 layout: post
 title: Week 1
 date: 2022-01-10 12:00:00
-term: second
+term: 2
 description: Week 1 course materials # Add post description (optional)
 detailed-description: Drs. Angie Laird and David Kennedy introduce the ABCD-ReproNim course, the ABCD Study, and ReproNim - a center for Reproducible Neuroimaging Computation.
 img: week01.jpg # Add image post (optional)

--- a/_posts/2022-01-17-week-2.md
+++ b/_posts/2022-01-17-week-2.md
@@ -2,7 +2,7 @@
 layout: post
 title: Week 2
 date: 2022-01-17 12:00:00
-term: second
+term: 2
 description: Week 2 course materials # Add post description (optional)
 detailed-description: Drs. Wesley Thompson and Dorota Jarecka talk about accessing ABCD data using DEAP, how to use the command line, and introduce git as a resource for version control.
 img: week02.jpg # Add image post (optional)

--- a/_posts/2022-01-24-week-3.md
+++ b/_posts/2022-01-24-week-3.md
@@ -2,7 +2,7 @@
 layout: post
 title: Week 3
 date: 2022-01-24 12:00:00
-term: second
+term: 2
 description: Week 3 course materials # Add post description (optional)
 detailed-description: Drs. Hugh Garavan and Dorota Jarecka talk about ABCD data sampling, participant recruitment and retention, and how to use and manage containers to keep tidy and reproducible computational environments!
 img: week03.jpg # Add image post (optional)

--- a/_posts/2022-01-31-week-4.md
+++ b/_posts/2022-01-31-week-4.md
@@ -2,7 +2,7 @@
 layout: post
 title: Week 4
 date: 2022-01-31 12:00:00
-term: second
+term: 2
 description: Week 4 course materials # Add post description (optional)
 detailed-description: Drs. Damien Fair and Jean-Baptiste Poline talk about ABCD imaging measures, pre-registration, and P-hacking.
 img: week04.jpg # Add image post (optional)

--- a/_posts/2022-02-07-week-5.md
+++ b/_posts/2022-02-07-week-5.md
@@ -2,7 +2,7 @@
 layout: post
 title: Week 5
 date: 2022-02-07 12:00:00
-term: second
+term: 2
 description: Week 5 course materials # Add post description (optional)
 detailed-description: Drs. Susan Tapert and Maryann Martone talk about ABCD neurocognitive assessments, FAIR Data, and Semantic Markup 1.
 img: week05.jpg # Add image post (optional)

--- a/_posts/2022-02-14-week-6.md
+++ b/_posts/2022-02-14-week-6.md
@@ -2,7 +2,7 @@
 layout: post
 title: Week 6
 date: 2022-02-14 12:00:00
-term: second
+term: 2
 description: Week 6 course materials # Add post description (optional)
 detailed-description: Drs. Krista Lisdahl and David Keator talk about ABCD substance use assessments and more about the semantic markup of data (including how to work with BIDS!).
 img: week06.jpg # Add image post (optional)

--- a/_posts/2022-02-21-week-7.md
+++ b/_posts/2022-02-21-week-7.md
@@ -2,7 +2,7 @@
 layout: post
 title: Week 7
 date: 2022-02-21 12:00:00
-term: second
+term: 2
 description: Week 7 course materials # Add post description (optional)
 detailed-description: Drs. Deanna Barch and Jean-Baptiste Poline talk about ABCD demographic, physical, and mental health assessments and ReproNim concepts about scientific questions and statistical issues.
 img: week07.jpg # Add image post (optional)

--- a/_posts/2022-02-28-week-8.md
+++ b/_posts/2022-02-28-week-8.md
@@ -2,7 +2,7 @@
 layout: post
 title: Week 8
 date: 2022-02-28 12:00:00
-term: second
+term: 2
 description: Week 8 course materials # Add post description (optional)
 detailed-description: Drs. Raul Gonzalez and Adina Wagner talk about ABCD culture and environmental assessments and ReproNim concepts about data versioning and transformation using DataLad.
 img: week08.jpg # Add image post (optional)

--- a/_posts/2022-03-07-week-9.md
+++ b/_posts/2022-03-07-week-9.md
@@ -2,7 +2,7 @@
 layout: post
 title: Week 9
 date: 2022-03-07 12:00:00
-term: second
+term: 2
 description: Week 9 course materials # Add post description (optional)
 detailed-description: Drs. Kristina Uban and our own Satra Ghosh talk about ABCD biospecimen measures and ReproNim concepts about reproducible workflows and analyses.
 img: week09.jpg # Add image post (optional)

--- a/_posts/2022-03-14-week-10.md
+++ b/_posts/2022-03-14-week-10.md
@@ -2,7 +2,7 @@
 layout: post
 title: Week 10
 date: 2022-03-14 12:00:00
-term: second
+term: 2
 description: Week 10 course materials # Add post description (optional)
 detailed-description: Drs. Kara Bagot and Yaroslav Halchenko talk about ABCD Novel Technologies (the mobile, wearable, and social media data collected from ABCD Study participants) and ReproMan, the execution and environment manager.
 img: week10.jpg # Add image post (optional)

--- a/_posts/2022-03-21-week-11.md
+++ b/_posts/2022-03-21-week-11.md
@@ -2,7 +2,7 @@
 layout: post
 title: Week 11
 date: 2022-03-21 12:00:00
-term: second
+term: 2
 description: Week 11 course materials # Add post description (optional)
 detailed-description: Drs. Katherine Bottenhorn and Julianna Bates talk about visualizing data in Python and creating re-executable research publications with ReproPub.
 img: week11.jpg # Add image post (optional)

--- a/_posts/2022-03-28-week-12.md
+++ b/_posts/2022-03-28-week-12.md
@@ -2,7 +2,7 @@
 layout: post
 title: Week 12
 date: 2022-03-28 12:00:00
-term: second
+term: 2
 description: Week 12 course materials # Add post description (optional)
 detailed-description: Drs. Tara Madhyastha and Gaël Varoquaux talk about longitudinal modeling and machine learning analytic methods.
 img: week12.jpg # Add image post (optional)

--- a/_posts/2022-04-04-project-month.md
+++ b/_posts/2022-04-04-project-month.md
@@ -2,7 +2,7 @@
 layout: resources
 title: Project Month
 date: 2022-04-04 12:00:00
-term: second
+term: 2
 description: Project Month # Add post description (optional)
 img: project_month.jpg # Add image post (optional)
 ---

--- a/index.html
+++ b/index.html
@@ -1,13 +1,13 @@
 ---
 layout: main
 ---
-{% for post in paginator.posts reversed %}
+{% for post in site.posts reversed %}
 
-    <!---to hide the resources page-->
+    <!---all posts with the term attribute and it's the current one-->
     {% if post.term == site.current_term %}
         <article class="post">
         {% if post.img %}
-            <a class="post-thumbnail" style="background-image: url({{"/assets/img/" | prepend: site.baseurl | append : post.img}})" href="{{post.url | prepend: site.baseurl}}"></a>
+            <a class="post-thumbnail" style="background-image: url({{'/assets/img/' | prepend: site.baseurl | append : post.img}})" href="{{post.url | prepend: site.baseurl}}"></a>
         {% else %}
         {% endif %}
         <div class="post-content">
@@ -22,5 +22,3 @@ layout: main
         </article>
     {% endif %}
 {% endfor %}
-
-{% include pagination.html %}

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@ layout: main
 {% for post in paginator.posts reversed %}
 
     <!---to hide the resources page-->
-    {% if post.hidden != true %}
+    {% if post.term == site.current_term %}
         <article class="post">
         {% if post.img %}
             <a class="post-thumbnail" style="background-image: url({{"/assets/img/" | prepend: site.baseurl | append : post.img}})" href="{{post.url | prepend: site.baseurl}}"></a>

--- a/misc/_posts/2021-10-05-past-materials.html
+++ b/misc/_posts/2021-10-05-past-materials.html
@@ -1,0 +1,51 @@
+---
+layout: main
+---
+{% assign old_posts = "" | split: "" %}
+{% for post in site.posts %}
+  <!---all pages with a "term" attribute less than the current one-->
+  {% if post.term < site.current_term %}
+    {% assign old_posts = old_posts | push: post %}
+  {% endif %}
+{% endfor %}
+
+{% assign terms = "" | split: "" %}
+{% for post in old_posts %}
+  {% assign terms = terms | push: post.term %}
+{% endfor %}
+{% assign terms = terms | uniq %}
+
+{% for term in terms %}
+    <h1>Term {{ term }}</h1>
+
+	<div class="bigspacer"></div>
+
+	{% assign term_posts = "" | split: "" %}
+	{% for post in old_posts %}
+		{% if post.term == term %}
+		  {% assign term_posts = term_posts | push: post %}
+		{% endif %}
+	{% endfor %}
+
+    {% for post in term_posts reversed %}
+        <article class="post">
+            <a class="post-thumbnail" style="background-image: url({{'/assets/img/' | prepend: site.baseurl | append : post.img}})" href="{{post.url | prepend: site.baseurl}}"></a>
+
+            <div class="post-content">
+                <h2 class="post-title"><a href="{{post.url | prepend: site.baseurl}}">{{post.title}}</a></h2>
+                {% if post.abcd_title %}
+                    <p>{{ post.abcd_title }} / {{ post.repronim_title }}</p>
+                {% else %}
+                    <p>{{ post.description }}</p>
+                {% endif %}
+                <span class="post-date">{{post.date | date: '%b %d %Y'}}</span>
+            </div>
+        </article>
+    {% endfor %}
+
+	<div class="bigspacer"></div>
+
+	{% if term != terms[-1] %}
+		<hr/>
+	{% endif %}
+{% endfor %}


### PR DESCRIPTION
Closes #84. I had to disable pagination to make this work.

Changes proposed:

- Disable pagination. Pagination seems to only operate across _all_ posts, regardless of any tags or filtering. That means that we were able to _show_ specific posts in the paginated list, but there would end up being new, empty pages, to account for all of the posts on the site.
- Add new page for old materials.
- Add last year's weekly pages back in, and add in `term: 1` to all of them.
- Add a top-level variable (`site.current_term`) that will let you filter post files based on their `term` variables more easily.