### PR TITLE
Add some updates for Week 1

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -42,7 +42,7 @@ layout: main
                     {% endfor %}
                 {% else %}
                     <div class="smallhead subtle">
-                        <b>Assignments</b>: Data Exercise (to be added). Please see the <a class="off" href="{{ page.exercises }}"> 2020 Course Data Exercise</a>.
+                        <b>Assignments</b>: Data Exercise (to be added). Please see the <a class="off" href="https://abcd-repronim.github.io/materials/past-materials/"> 2020 Course Data Exercise</a>.
                     </div>
                 {% endif %}
                 <!-- End Exercises conditional Content -->

--- a/_posts/2022-01-10-week-1.md
+++ b/_posts/2022-01-10-week-1.md
@@ -11,13 +11,14 @@ tags: []
 
 qa_doc: https://docs.google.com/document/d/14NLnourpjasNaJw8HjAQXDXruULLYN4NK-yNzY0K1Xo/edit?usp=sharing
 2020-exercises: "https://forms.gle/ybaY6HgLnfcYQ7kXA"
-assignment_links: #["https://forms.gle/ybaY6HgLnfcYQ7kXA", "https://forms.gle/o1ucqPSfhpvgvLh78",]
-assignment_names: #["Week 1 Data Exercise", "Pre-Course Survey",]
+assignment_links: ["https://docs.google.com/forms/d/e/1FAIpQLSdslts4HT4x0GSb-reBhNFL3B8KGZ-LDmTpquNmt0N7uQe4QQ/viewform?usp=sf_link", "https://docs.google.com/forms/d/e/1FAIpQLSeFog9Uof5SyHO3DEFstZWGBLqO-3pQm7Hiy2xHgPInSgtoJQ/viewform?usp=sf_link",]
+assignment_names: ["Week 1 Data Exercise", "Pre-Course Survey",]
 qa_video: "https://www.youtube.com/embed/MUIuePnQzX8"
+
 
 abcd_title: Introduction to the ABCD Study®
 abcd_video: https://www.youtube.com/embed/z6jcWAmDhF0
-abcd_slides: "https://drive.google.com/file/d/1o6oYZ-2WDIrOoTMsi3F8idUxed3aZStm/view?usp=sharing"
+abcd_slides: "https://drive.google.com/file/d/1CYvkJiogjVa0Bc8TxS-2HB5-CJ8wsltx/view?usp=sharing"
 abcd_reading_links: ["https://www.sciencedirect.com/science/article/pii/S1878929317300725", "https://www.sciencedirect.com/science/article/pii/S1878929317301883", "https://www.sciencedirect.com/science/article/pii/S1878929317302268"]
 abcd_reading_names: ["Volkow et al.: 'The conception of the ABCD study: From substance use to a broad NIH collaboration'", "Jernigan et al.: 'Introduction (Developmental Cognitive Neuroscience)'", "Auchter et al.: 'A description of the ABCD organizational structure and communication framework'"]
 


### PR DESCRIPTION
- Update the abcd slides link to remove 2020 schedule/TA slide stack
- Fix the 2020 Course Data Exercises link in all pages (there is probably a more elegant way to do this that isn't hard coding the url so if anyone else has suggestions feel free to edit!)
- Open up the Quiz 1 for Week 1 with an updated 2022 link
- Add the 2022 Pre-Course Survey as an assignment for Week 1